### PR TITLE
Add filter panel sidebar

### DIFF
--- a/css/filter-panel.css
+++ b/css/filter-panel.css
@@ -1,0 +1,37 @@
+#filter-panel {
+  position: fixed;
+  left: 90px;
+  top: 0;
+  bottom: 0;
+  width: 250px;
+  background: rgba(11, 11, 24, 0.9);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-right: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 32px;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease-in-out;
+  z-index: 99;
+}
+#filter-panel.visible { transform: translateX(0); }
+.panel-title { font-family: var(--font-head); font-size: 24px; color: var(--neon-pink); margin-bottom: 24px; }
+.chip-group { margin-bottom: 20px; }
+.chip-group-title { font-size: 16px; color: var(--neon-blue); margin-bottom: 12px; text-transform: uppercase; letter-spacing: 1px; }
+#filter-panel .chip {
+  margin: 4px;
+  padding: 6px 14px;
+  border-radius: 20px;
+  font-size: 13px;
+  background: #0b0b18;
+  border: 1px solid var(--neon-blue);
+  color: var(--neon-blue);
+  cursor: pointer;
+  transition: background .15s, box-shadow .15s, color .15s;
+}
+#filter-panel .chip:hover { box-shadow:0 0 8px var(--neon-blue); }
+#filter-panel .chip.active {
+  background: var(--neon-blue);
+  color: #050510;
+  box-shadow: 0 0 12px var(--neon-blue);
+  font-weight: 700;
+}

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>PawsVdeX</title>
   <link rel="stylesheet" href="css/style.css" />
+  <link rel="stylesheet" href="css/filter-panel.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&family=Orbitron:wght@400;700&display=swap" rel="stylesheet">

--- a/js/components/filterPanel.js
+++ b/js/components/filterPanel.js
@@ -1,0 +1,35 @@
+import { h } from '../core/dom.js';
+import { CREATURES } from '../data.js';
+import { filterState } from '../core/filterState.js';
+
+export function createFilterPanel() {
+  const elements = [...new Set(CREATURES.map(c => c.element))].sort();
+  const habitats = [...new Set(CREATURES.map(c => c.habitat))].sort();
+
+  const createChipGroup = (title, options, onToggle) => {
+    return h('div', { className: 'chip-group' },
+      h('h3', { className: 'chip-group-title' }, title),
+      ...options.map(option => h('button', { className: 'chip', onClick: () => onToggle(option) }, option))
+    );
+  };
+
+  const panel = h('div', { id: 'filter-panel', className: 'sidebar-panel' },
+    h('h2', { className: 'panel-title' }, 'Filter Creatures'),
+    createChipGroup('Element', elements, filterState.toggleElement),
+    createChipGroup('Habitat', habitats, filterState.toggleHabitat)
+  );
+
+  const updateChipStates = () => {
+    const active = filterState.get();
+    panel.querySelectorAll('.chip').forEach(chip => {
+      const label = chip.textContent;
+      const isActive = active.elements.has(label) || active.habitats.has(label);
+      chip.classList.toggle('active', isActive);
+    });
+  };
+
+  updateChipStates();
+  const unsubscribe = filterState.subscribe(updateChipStates);
+
+  return { el: panel, destroy: unsubscribe };
+}

--- a/js/components/sidebar.js
+++ b/js/components/sidebar.js
@@ -1,28 +1,43 @@
 import { h } from '../core/dom.js';
+import { createFilterPanel } from './filterPanel.js';
 
 export function initSidebar(router) {
+  const filterPanel = createFilterPanel();
+  document.body.appendChild(filterPanel.el);
   const nav = document.getElementById('sidebar');
+
   const buttons = [
-    { page: 'home',     label: 'Home',          path: 'M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z' },
-    { page: 'dex',      label: 'Browse Dex',    path: 'M4 4h16v16H4z' },
-    { page: 'type',     label: 'Type Index',    path: 'M12 2l9 16H3z' },
-    { page: 'snapshot', label: 'Royal Snapshot',path: 'M5 3h14v14H5z M3 19l4-4' },
-    { page: 'ai',       label: 'AI Chat',       path: 'M12 2a4 4 0 0 1 4 4v12a4 4 0 0 1-8 0V6a4 4 0 0 1 4-4z'}
+    { page: 'home', label: 'Home', path: 'M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z' },
+    { page: 'dex', label: 'Browse Dex', path: 'M4 4h16v16H4z' },
+    { page: 'filter', label: 'Filter', path: 'M3 17v2h6v-2H3zM3 5v2h10V5H3zm10 16v-2h8v-2h-8v-2h-2v6h2zM7 9v2H3v2h4v2h2V9H7zm14 4v-2H11v2h10zm-6-4h2V7h4V5h-4V3h-2v6z'},
+    { page: 'type', label: 'Type Index', path: 'M12 2l9 16H3z' },
+    { page: 'snapshot', label: 'Royal Snapshot', path: 'M5 3h14v14H5z M3 19l4-4' },
+    { page: 'ai', label: 'AI Chat', path: 'M12 2a4 4 0 0 1 4 4v12a4 4 0 0 1-8 0V6a4 4 0 0 1 4-4z'}
   ];
 
   nav.append(
-    ...buttons.map(b =>
-      h('div',
-        {
-          className: 'sidebar-btn',
-          dataset: { page: b.page },
-          title: b.label,
-          onClick: () => router.go(b.page)
-        },
-        h('svg', { viewBox: '0 0 24 24', 'aria-hidden': true },
-          h('path', { d: b.path, fill: 'none', strokeWidth: 2, stroke: 'currentColor' })
-        )
-      )
-    )
+    ...buttons.map(b => {
+      const btn = h('div', { className: 'sidebar-btn', dataset: { page: b.page }, title: b.label });
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.setAttribute('viewBox', '0 0 24 24');
+      svg.setAttribute('aria-hidden', 'true');
+      const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+      path.setAttribute('d', b.path);
+      path.setAttribute('fill', 'none');
+      path.setAttribute('stroke-width', '2');
+      path.setAttribute('stroke', 'currentColor');
+      svg.appendChild(path);
+      btn.appendChild(svg);
+
+      if (b.page === 'filter') {
+        btn.addEventListener('click', () => filterPanel.el.classList.toggle('visible'));
+      } else {
+        btn.addEventListener('click', () => {
+          filterPanel.el.classList.remove('visible');
+          router.go(b.page);
+        });
+      }
+      return btn;
+    })
   );
 }

--- a/js/core/filterState.js
+++ b/js/core/filterState.js
@@ -1,0 +1,18 @@
+const activeFilters = { elements: new Set(), habitats: new Set() };
+const listeners = new Set();
+
+export const filterState = {
+  get: () => ({ ...activeFilters }),
+  toggleElement: (element) => {
+    activeFilters.elements.has(element) ? activeFilters.elements.delete(element) : activeFilters.elements.add(element);
+    listeners.forEach(listener => listener());
+  },
+  toggleHabitat: (habitat) => {
+    activeFilters.habitats.has(habitat) ? activeFilters.habitats.delete(habitat) : activeFilters.habitats.add(habitat);
+    listeners.forEach(listener => listener());
+  },
+  subscribe: (callback) => {
+    listeners.add(callback);
+    return () => listeners.delete(callback);
+  }
+};

--- a/js/views/home.js
+++ b/js/views/home.js
@@ -2,26 +2,18 @@ import { h } from '../core/dom.js';
 import { CREATURES as creatures } from '../data.js';
 import { card } from '../components/card.js';
 import { router } from '../core/router.js';
-import { filterBar } from '../components/filterBar.js';
+import { filterState } from '../core/filterState.js';
 
-// Helper to get featured creatures
 function getFeatured() {
     const shuffled = [...creatures].sort(() => 0.5 - Math.random());
     return shuffled.slice(0, 3);
 }
 
 export function showHome() {
-  const elements = [...new Set(creatures.map(c => c.element))].sort();
-  const habitats = [...new Set(creatures.map(c => c.habitat))].sort();
-
-  const activeFilters = {
-    elements: new Set(),
-    habitats: new Set()
-  };
-
   const grid = h('div', { id: 'all-creatures', className: 'grid' });
 
   function renderGrid() {
+    const activeFilters = filterState.get();
     const filteredCreatures = creatures.filter(c => {
       const elementMatch = !activeFilters.elements.size || activeFilters.elements.has(c.element);
       const habitatMatch = !activeFilters.habitats.size || activeFilters.habitats.has(c.habitat);
@@ -33,34 +25,23 @@ export function showHome() {
     grid.replaceChildren(frag);
   }
 
-  const onElementToggle = (label, isActive) => {
-    isActive ? activeFilters.elements.add(label) : activeFilters.elements.delete(label);
-    renderGrid();
-  };
+  renderGrid();
+  const unsubscribe = filterState.subscribe(renderGrid);
 
-  const onHabitatToggle = (label, isActive) => {
-    isActive ? activeFilters.habitats.add(label) : activeFilters.habitats.delete(label);
-    renderGrid();
-  };
-  
-  const section = h('section', {},
-    h('h1', { id: 'home-title' }, 'PawsVdeX'),
-    h('p', {}, 'Explore the magical wilds of Pawsville.'),
-    h('h2', { className: 'subhead' }, 'Featured Creatures'),
-    h('div', { id: 'featured', className: 'flex-row' },
-      ...getFeatured().map(c => card(c, router))
+  const section = h('section', { id: 'home-view' },
+    h('div', { className: 'view-header' },
+        h('h1', { id: 'home-title' }, 'PawsVdeX'),
+        h('p', {}, 'Explore the magical wilds of Pawsville.')
     ),
-    h('h2', { className: 'subhead' }, 'Filter Creatures'),
-    filterBar('Element', elements, onElementToggle),
-    filterBar('Habitat', habitats, onHabitatToggle),
-    h('h2', { className: 'subhead' }, 'All Creatures'),
-    grid
+    h('div', { className: 'content-panel featured-panel' },
+        h('h2', { className: 'subhead' }, 'Featured Creatures'),
+        h('div', { id: 'featured', className: 'flex-row' }, ...getFeatured().map(c => card(c, router)))
+    ),
+    h('div', { className: 'content-panel dex-panel' },
+        h('h2', { className: 'subhead' }, 'All Creatures'),
+        grid
+    )
   );
-  
-  renderGrid(); // Initial render
 
-  return {
-    el: section,
-    destroy: null // This view has no ongoing processes to clean up
-  };
+  return { el: section, destroy: unsubscribe };
 }


### PR DESCRIPTION
## Summary
- centralize filter state in `js/core/filterState.js`
- implement filter panel UI component and styling
- insert filter panel toggle in the sidebar
- update home view to use the central state
- include new stylesheet in `index.html`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68883d37c5e0832bb718553fc5410705