### PR TITLE
Implement filter sidebar and detail UI overhaul

### DIFF
--- a/css/filter-panel.css
+++ b/css/filter-panel.css
@@ -1,0 +1,19 @@
+/* css/filter-panel.css */
+#filter-panel {
+  position: fixed;
+  left: 90px;
+  top: 0;
+  bottom: 0;
+  width: 250px;
+  background: rgba(11, 11, 24, 0.9);
+  backdrop-filter: blur(10px);
+  border-right: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 32px;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease-in-out;
+  z-index: 99;
+}
+#filter-panel.visible { transform: translateX(0); }
+.panel-title { font-family: var(--font-head); font-size: 24px; color: var(--neon-pink); margin-bottom: 24px; }
+.chip-group { margin-bottom: 20px; }
+.chip-group-title { font-size: 16px; color: var(--neon-blue); margin-bottom: 12px; text-transform: uppercase; letter-spacing: 1px; }

--- a/css/style.css
+++ b/css/style.css
@@ -303,3 +303,61 @@ section::-webkit-scrollbar-thumb {
   opacity: 0.4;
   cursor: not-allowed;
 }
+
+/* ---------- PANEL STYLES ---------- */
+.content-panel {
+  background: rgba(11, 11, 24, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 24px 32px;
+  margin-top: 32px;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+.content-panel .subhead {
+  margin-top: 0;
+  margin-bottom: 24px;
+}
+
+/* ---------- DETAIL PAGE LAYOUT ---------- */
+#detail .content-panel { padding: 32px; }
+.detail-main { display: flex; gap: 32px; }
+.viewer-container { display: flex; flex-direction: column; gap: 16px; }
+
+#stage-selector {
+  width: 100%;
+  padding: 10px;
+  background: #0b0b18;
+  border: 1px solid var(--neon-blue);
+  color: var(--neon-blue);
+  border-radius: 8px;
+  font-family: var(--font-body);
+  font-size: 16px;
+}
+
+#media-rail {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  margin-top: 24px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  padding-top: 24px;
+}
+
+.media-slot {
+  aspect-ratio: 16 / 10;
+  background: #0b0b18;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.media-slot img, .media-slot video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>PawsVdeX</title>
   <link rel="stylesheet" href="css/style.css" />
+  <link rel="stylesheet" href="css/filter-panel.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&family=Orbitron:wght@400;700&display=swap" rel="stylesheet">

--- a/js/components/filterPanel.js
+++ b/js/components/filterPanel.js
@@ -1,0 +1,36 @@
+// js/components/filterPanel.js
+import { h } from '../core/dom.js';
+import { CREATURES } from '../data.js';
+import { filterState } from '../core/filterState.js';
+
+export function createFilterPanel() {
+  const elements = [...new Set(CREATURES.map(c => c.element))].sort();
+  const habitats = [...new Set(CREATURES.map(c => c.habitat))].sort();
+
+  const createChipGroup = (title, options, onToggle) => {
+    return h('div', { className: 'chip-group' },
+      h('h3', { className: 'chip-group-title' }, title),
+      ...options.map(option => h('button', { className: 'chip', onClick: () => onToggle(option) }, option))
+    );
+  };
+
+  const panel = h('div', { id: 'filter-panel', className: 'sidebar-panel' },
+    h('h2', { className: 'panel-title' }, 'Filter Creatures'),
+    createChipGroup('Element', elements, filterState.toggleElement),
+    createChipGroup('Habitat', habitats, filterState.toggleHabitat)
+  );
+
+  const updateChipStates = () => {
+    const active = filterState.get();
+    panel.querySelectorAll('.chip').forEach(chip => {
+      const label = chip.textContent;
+      const isActive = active.elements.has(label) || active.habitats.has(label);
+      chip.classList.toggle('active', isActive);
+    });
+  };
+
+  updateChipStates();
+  const unsubscribe = filterState.subscribe(updateChipStates);
+
+  return { el: panel, destroy: unsubscribe };
+}

--- a/js/components/sidebar.js
+++ b/js/components/sidebar.js
@@ -1,28 +1,33 @@
 import { h } from '../core/dom.js';
+import { createFilterPanel } from './filterPanel.js';
 
 export function initSidebar(router) {
+  const filterPanel = createFilterPanel();
+  document.body.appendChild(filterPanel.el);
   const nav = document.getElementById('sidebar');
+
   const buttons = [
-    { page: 'home',     label: 'Home',          path: 'M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z' },
-    { page: 'dex',      label: 'Browse Dex',    path: 'M4 4h16v16H4z' },
-    { page: 'type',     label: 'Type Index',    path: 'M12 2l9 16H3z' },
-    { page: 'snapshot', label: 'Royal Snapshot',path: 'M5 3h14v14H5z M3 19l4-4' },
-    { page: 'ai',       label: 'AI Chat',       path: 'M12 2a4 4 0 0 1 4 4v12a4 4 0 0 1-8 0V6a4 4 0 0 1 4-4z'}
+    { page: 'home', label: 'Home', path: 'M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z' },
+    { page: 'dex', label: 'Browse Dex', path: 'M4 4h16v16H4z' },
+    { page: 'filter', label: 'Filter', path: 'M3 17v2h6v-2H3zM3 5v2h10V5H3zm10 16v-2h8v-2h-8v-2h-2v6h2zM7 9v2H3v2h4v2h2V9H7zm14 4v-2H11v2h10zm-6-4h2V7h4V5h-4V3h-2v6z'},
+    { page: 'type', label: 'Type Index', path: 'M12 2l9 16H3z' },
+    { page: 'snapshot', label: 'Royal Snapshot', path: 'M5 3h14v14H5z M3 19l4-4' },
+    { page: 'ai', label: 'AI Chat', path: 'M12 2a4 4 0 0 1 4 4v12a4 4 0 0 1-8 0V6a4 4 0 0 1 4-4z'}
   ];
 
   nav.append(
-    ...buttons.map(b =>
-      h('div',
-        {
-          className: 'sidebar-btn',
-          dataset: { page: b.page },
-          title: b.label,
-          onClick: () => router.go(b.page)
-        },
-        h('svg', { viewBox: '0 0 24 24', 'aria-hidden': true },
-          h('path', { d: b.path, fill: 'none', strokeWidth: 2, stroke: 'currentColor' })
-        )
-      )
-    )
+    ...buttons.map(b => {
+      const btn = h('div', { className: 'sidebar-btn', dataset: { page: b.page }, title: b.label });
+      btn.innerHTML = `<svg viewBox="0 0 24 24"><path d="${b.path}" fill="none" stroke-width="2" stroke="currentColor"/></svg>`;
+      if (b.page === 'filter') {
+        btn.addEventListener('click', () => filterPanel.el.classList.toggle('visible'));
+      } else {
+        btn.addEventListener('click', () => {
+          filterPanel.el.classList.remove('visible');
+          router.go(b.page);
+        });
+      }
+      return btn;
+    })
   );
 }

--- a/js/core/filterState.js
+++ b/js/core/filterState.js
@@ -1,0 +1,23 @@
+// js/core/filterState.js
+const activeFilters = { elements: new Set(), habitats: new Set() };
+const listeners = new Set();
+
+export const filterState = {
+  get: () => ({ ...activeFilters }),
+  toggleElement: (element) => {
+    activeFilters.elements.has(element)
+      ? activeFilters.elements.delete(element)
+      : activeFilters.elements.add(element);
+    listeners.forEach(listener => listener());
+  },
+  toggleHabitat: (habitat) => {
+    activeFilters.habitats.has(habitat)
+      ? activeFilters.habitats.delete(habitat)
+      : activeFilters.habitats.add(habitat);
+    listeners.forEach(listener => listener());
+  },
+  subscribe: (callback) => {
+    listeners.add(callback);
+    return () => listeners.delete(callback);
+  }
+};

--- a/js/data.js
+++ b/js/data.js
@@ -1,5 +1,5 @@
 /*
- * Placeholder data – enough to let the UI work end‑to‑end.
+ * Placeholder data – enough to let the UI work end-to-end.
  * Each object mimics the structure planned for the final XLSX import.
  */
 export const CREATURES = [
@@ -11,10 +11,13 @@ export const CREATURES = [
     rarity: 3,
     img: 'https://via.placeholder.com/150/16d5ff/050510?text=Glowtail',
     stages: [
-      { name: 'Juvenile Glowtail', type: 'image', src: 'https://via.placeholder.com/350/16d5ff/050510?text=Stage+1' },
-      { name: 'Mystic Glowtail',   type: 'image', src: 'https://via.placeholder.com/350/d451ff/050510?text=Stage+2' }
+      { name: 'Juvenile Glowtail', imgSrc: 'assets/img/stage1_glowtail.jpg', modelSrc: 'assets/models/stage1_glowtail.glb' },
+      { name: 'Mystic Glowtail', imgSrc: 'assets/img/stage2_glowtail.jpg', modelSrc: 'assets/models/stage2_glowtail.glb' }
     ],
-    media: { type: 'video', src: 'assets/img/glowtail-loop.mp4' },
+    media: {
+      video: 'assets/video/glowtail-loop.mp4',
+      candids: ['assets/img/glowtail_candid1.jpg', 'assets/img/glowtail_candid2.jpg']
+    },
     role: 'Guides lost travellers',
     behaviour: 'Curious, nimble',
     notable: 'Royal Playroom Fire Chase'
@@ -27,10 +30,13 @@ export const CREATURES = [
     rarity: 2,
     img: 'https://via.placeholder.com/150/3dff83/050510?text=Budblop',
     stages: [
-      { name: 'Sproutling', type: 'image', src: 'https://via.placeholder.com/350/3dff83/050510?text=Stage+1' },
-      { name: 'Bloomblop', type: 'image', src: 'https://via.placeholder.com/350/d451ff/050510?text=Stage+2' }
+      { name: 'Sproutling', imgSrc: 'assets/img/stage1_budblop.jpg', modelSrc: 'assets/models/stage1_budblop.glb' },
+      { name: 'Bloomblop', imgSrc: 'assets/img/stage2_budblop.jpg', modelSrc: 'assets/models/stage2_budblop.glb' }
     ],
-    media: null,
+    media: {
+      video: 'assets/video/budblop-loop.mp4',
+      candids: ['assets/img/budblop_candid1.jpg', 'assets/img/budblop_candid2.jpg']
+    },
     role: 'Absorbs moonlight to grow',
     behaviour: 'Shy, gentle',
     notable: 'First bloom during the Great Eclipse'
@@ -43,13 +49,17 @@ export const CREATURES = [
     rarity: 4,
     img: 'https://via.placeholder.com/150/ff6666/050510?text=Scorchbit',
     stages: [
-      { name: 'Emberling', type: 'image', src: 'https://via.placeholder.com/350/ff6666/050510?text=Stage+1' },
-      { name: 'Inferno Whelp', type: 'image', src: 'https://via.placeholder.com/350/d451ff/050510?text=Stage+2' }
+      { name: 'Emberling', imgSrc: 'assets/img/stage1_scorchbit.jpg', modelSrc: 'assets/models/stage1_scorchbit.glb' },
+      { name: 'Inferno Whelp', imgSrc: 'assets/img/stage2_scorchbit.jpg', modelSrc: 'assets/models/stage2_scorchbit.glb' }
     ],
-    media: null,
+    media: {
+      video: 'assets/video/scorchbit-loop.mp4',
+      candids: ['assets/img/scorchbit_candid1.jpg', 'assets/img/scorchbit_candid2.jpg']
+    },
     role: 'Guardian of forgotten embers',
     behaviour: 'Playful, territorial',
     notable: 'Lit the ceremonial bonfire'
-  },
+  }
   // Add more creature objects here... up to 80
 ];
+

--- a/js/views/detail.js
+++ b/js/views/detail.js
@@ -12,32 +12,55 @@ export function showDetail({ id }) {
     };
   }
 
-  const viewer = createViewer();
+  // NOTE: This assumes 'createViewer' can accept a model URL and has a 'loadModel' method.
+  const viewer = createViewer(350, 350, creature.stages[0].modelSrc);
   const viewBox = h('div', { id: 'viewer' }, viewer.canvas);
 
-  const stageColors = [0x55eaff, 0xff66ff, 0x3dff83]; // Example colors for stages
-  const stageBtns = creature.stages.map((s, idx) =>
-    h('button', { onClick: () => viewer.setColor(stageColors[idx] || 0xffffff) }, s.name)
-  );
+  const stageSelector = h('select', {
+    id: 'stage-selector',
+    onChange: (e) => {
+      const selectedStage = creature.stages[e.target.value];
+      if (viewer.loadModel && selectedStage.modelSrc) {
+        viewer.loadModel(selectedStage.modelSrc);
+      }
+    }
+  }, ...creature.stages.map((stage, index) => h('option', { value: index }, stage.name)));
+
+  const mediaSlots = [];
+  const firstEvo = creature.stages[1];
+  mediaSlots.push(h('div', { className: 'media-slot' },
+    firstEvo ? h('img', { src: firstEvo.imgSrc, alt: firstEvo.name }) :
+    creature.media.candids[0] ? h('img', { src: creature.media.candids[0], alt: 'Candid' }) : null
+  ));
+
+  const secondEvo = creature.stages[2];
+  mediaSlots.push(h('div', { className: 'media-slot' },
+    secondEvo ? h('img', { src: secondEvo.imgSrc, alt: secondEvo.name }) :
+    creature.media.candids[1] ? h('img', { src: creature.media.candids[1], alt: 'Candid' }) : null
+  ));
+
+  mediaSlots.push(h('div', { className: 'media-slot video-slot' },
+    creature.media.video ? h('video', { src: creature.media.video, loop: true, muted: true, autoplay: true, playsinline: true }) : null
+  ));
+
+  const mediaRail = h('div', { id: 'media-rail' }, ...mediaSlots);
 
   const section = h('section', { id: 'detail' },
-    h('div', { className: 'flex-row' },
-      viewBox,
-      h('div', { id: 'bio' },
-        h('h2', {}, `#${creature.id} — ${creature.name}`),
-        h('p', {}, h('strong', {}, 'Element: '), creature.element),
-        h('p', {}, h('strong', {}, 'Habitat: '), creature.habitat),
-        h('p', {}, h('strong', {}, 'Role: '), creature.role),
-        h('p', {}, h('strong', {}, 'Behaviour: '), creature.behaviour),
-        h('p', { className: 'note' }, `Notable Appearance: ${creature.notable}`),
-        h('div', { id: 'stage-btns' }, ...stageBtns)
-      )
+    h('div', { className: 'content-panel' },
+      h('div', { className: 'detail-main' },
+        h('div', { className: 'viewer-container' }, viewBox, stageSelector),
+        h('div', { id: 'bio' },
+          h('h2', {}, `#${creature.id} — ${creature.name}`),
+          h('p', {}, h('strong', {}, 'Element: '), creature.element),
+          h('p', {}, h('strong', {}, 'Habitat: '), creature.habitat),
+          h('p', {}, h('strong', {}, 'Role: '), creature.role),
+          h('p', {}, h('strong', {}, 'Behaviour: '), creature.behaviour),
+          h('p', { className: 'note' }, `Notable Appearance: ${creature.notable}`)
+        )
+      ),
+      mediaRail
     )
-    // Media rail could be added here if needed
   );
 
-  return {
-    el: section,
-    destroy: viewer.cleanup // Critical: link router lifecycle to viewer cleanup
-  };
+  return { el: section, destroy: viewer.cleanup };
 }

--- a/js/views/home.js
+++ b/js/views/home.js
@@ -2,65 +2,43 @@ import { h } from '../core/dom.js';
 import { CREATURES as creatures } from '../data.js';
 import { card } from '../components/card.js';
 import { router } from '../core/router.js';
-import { filterBar } from '../components/filterBar.js';
+import { filterState } from '../core/filterState.js';
 
-// Helper to get featured creatures
 function getFeatured() {
     const shuffled = [...creatures].sort(() => 0.5 - Math.random());
     return shuffled.slice(0, 3);
 }
 
 export function showHome() {
-  const elements = [...new Set(creatures.map(c => c.element))].sort();
-  const habitats = [...new Set(creatures.map(c => c.habitat))].sort();
-
-  const activeFilters = {
-    elements: new Set(),
-    habitats: new Set()
-  };
-
   const grid = h('div', { id: 'all-creatures', className: 'grid' });
 
   function renderGrid() {
+    const activeFilters = filterState.get();
     const filteredCreatures = creatures.filter(c => {
       const elementMatch = !activeFilters.elements.size || activeFilters.elements.has(c.element);
       const habitatMatch = !activeFilters.habitats.size || activeFilters.habitats.has(c.habitat);
       return elementMatch && habitatMatch;
     }).sort((a, b) => a.id - b.id);
-
-    const frag = document.createDocumentFragment();
-    filteredCreatures.forEach(c => frag.appendChild(card(c, router)));
-    grid.replaceChildren(frag);
+    grid.replaceChildren(...filteredCreatures.map(c => card(c, router)));
   }
 
-  const onElementToggle = (label, isActive) => {
-    isActive ? activeFilters.elements.add(label) : activeFilters.elements.delete(label);
-    renderGrid();
-  };
+  renderGrid();
+  const unsubscribe = filterState.subscribe(renderGrid);
 
-  const onHabitatToggle = (label, isActive) => {
-    isActive ? activeFilters.habitats.add(label) : activeFilters.habitats.delete(label);
-    renderGrid();
-  };
-  
-  const section = h('section', {},
-    h('h1', { id: 'home-title' }, 'PawsVdeX'),
-    h('p', {}, 'Explore the magical wilds of Pawsville.'),
-    h('h2', { className: 'subhead' }, 'Featured Creatures'),
-    h('div', { id: 'featured', className: 'flex-row' },
-      ...getFeatured().map(c => card(c, router))
+  const section = h('section', { id: 'home-view' },
+    h('div', { className: 'view-header' },
+        h('h1', { id: 'home-title' }, 'PawsVdeX'),
+        h('p', {}, 'Explore the magical wilds of Pawsville.')
     ),
-    h('h2', { className: 'subhead' }, 'Filter Creatures'),
-    filterBar('Element', elements, onElementToggle),
-    filterBar('Habitat', habitats, onHabitatToggle),
-    h('h2', { className: 'subhead' }, 'All Creatures'),
-    grid
+    h('div', { className: 'content-panel featured-panel' },
+        h('h2', { className: 'subhead' }, 'Featured Creatures'),
+        h('div', { id: 'featured', className: 'flex-row' }, ...getFeatured().map(c => card(c, router)))
+    ),
+    h('div', { className: 'content-panel dex-panel' },
+        h('h2', { className: 'subhead' }, 'All Creatures'),
+        grid
+    )
   );
-  
-  renderGrid(); // Initial render
 
-  return {
-    el: section,
-    destroy: null // This view has no ongoing processes to clean up
-  };
+  return { el: section, destroy: unsubscribe };
 }


### PR DESCRIPTION
## Summary
- add centralized filter state manager and sidebar panel
- restructure home page to use filter state and panel styles
- overhaul detail page with stage selector and media rail
- add panel styling and detail layout CSS
- update sample creature data to include media and model paths

## Testing
- `node --check js/views/detail.js`
- `node --check js/components/filterPanel.js`
- `node --check js/core/filterState.js`


------
https://chatgpt.com/codex/tasks/task_e_68883d0bd8dc832b989f4e8724699e5b